### PR TITLE
Bug fix: Trying to load an empty collection should not hang the loading process

### DIFF
--- a/lib/ummon.js
+++ b/lib/ummon.js
@@ -581,6 +581,7 @@ Ummon.prototype.createCollectionAndTasks = function(config, callback) {
   // Iterate over tasks (if they exist) and create them
   if (!config.tasks) return callback(new Error('Collection config must include tasks'));
   var tasks = Object.keys(config.tasks);
+  if (tasks.length == 0) return callback(new Error('Collection config must include tasks'));
   var pending = tasks.length;
   var called;
   tasks.forEach(function (task) {

--- a/lib/ummon.js
+++ b/lib/ummon.js
@@ -590,7 +590,10 @@ Ummon.prototype.createCollectionAndTasks = function(config, callback) {
     taskConfig.collection = config.collection;
     self.createTask(taskConfig, function (err, task) {
       // Only call callback with error once
-      if (err && !called && (called=true)) return callback(err);
+      if (err && !called) {
+        called = true;
+        return callback(err);
+      }
       if (!--pending) callback();
     });
   });

--- a/test/ummon.collections.test.js
+++ b/test/ummon.collections.test.js
@@ -39,6 +39,23 @@ test('Create a collection from an object', function(t){
   });
 })
 
+test('Try to load an empty collection', function(t){
+  t.plan(2);
+
+  var emptyCollection = {
+    "collection": "empty",
+    "config": {
+      "enabled": false
+    },
+    "tasks": {}
+  }
+
+  ummon.createCollectionAndTasks(emptyCollection, function(err){
+    t.pass('Whew! It did get to the callback')
+    t.type(err, Error, '... and passed an error to the callback');
+  });
+})
+
 
 
 var disabledCollection = {


### PR DESCRIPTION
We discovered that the existence of an empty tasks config file caused the callback at the end of `db.loadTasks` to never get called, which meant that `config.autoSave` was never turned back on after the loading process.